### PR TITLE
Got queue to begin building after first page (50 song limit) is loaded, while the rest of an artists songs load in the background (for artists whose song names haven't been cached yet). Also moved close button to left, and fixed coloring of queue items

### DIFF
--- a/src/lib/components/AppWindow.svelte
+++ b/src/lib/components/AppWindow.svelte
@@ -152,7 +152,7 @@
             
 
         <div class="title-text" style:font-size="{dimensions.height*0.042}px">{title}</div>
-        <button class="close-button" style="width:{closeButtonSize}px; height:{closeButtonSize}px;" on:click={onClose} style:right="{titleBarPadding * 2.5}px"></button>
+        <button class="close-button" style="width:{closeButtonSize}px; height:{closeButtonSize}px;" on:click={onClose} style:left="{titleBarPadding * 2.5}px"></button>
     </div>
     <div class="window-content" bind:this={contentElement}>
         <div class="content-area">

--- a/src/lib/components/QueueDisplay.svelte
+++ b/src/lib/components/QueueDisplay.svelte
@@ -144,7 +144,6 @@
         max-height: var(--max-height);
         display: flex;
         flex-direction: column;
-        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
     }
     
     .queue-container.embedded {
@@ -213,6 +212,7 @@
         transition: background-color 0.2s ease;
         min-height: var(--item-height);
         border: 1px solid transparent;
+        color: var(--primary-color);
     }
     
     .queue-item:hover {
@@ -235,6 +235,7 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        color: var(--primary-color);
     }
     
     .song-artist {
@@ -244,6 +245,7 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        color: var(--primary-color);
     }
     
     .queue-position {
@@ -258,6 +260,7 @@
         opacity: 0.7;
         min-width: var(--position-min-width);
         text-align: center;
+        color: var(--primary-color);
     }
     
     .empty-queue {

--- a/src/lib/services/queueManager.js
+++ b/src/lib/services/queueManager.js
@@ -88,6 +88,7 @@ export class CacheAwareQueueManager {
                 artist: artist.name
             }));
             
+            console.log('🧱 Beginning queue build from first-page songIds (placeholders created)');
             // Load the first song immediately
             const firstWithExcerpt = this.ensureExcerptForSong({ ...result.song });
             this.loadedSongs.set(firstWithExcerpt.id, firstWithExcerpt);


### PR DESCRIPTION
This pull request introduces improvements to the artist song caching and queue build process, focusing on faster initial loading and enhanced UI consistency. The main change is a new two-step caching strategy: the first page of songs is fetched and cached immediately to allow quick queue building, while the full song list is populated in the background. Additionally, several UI tweaks ensure consistent coloring and positioning in queue-related components.

**Backend caching and population improvements:**

* The `populateArtistSongsCore` function now accepts an `onlyFirstPage` option, allowing early exit after caching the first page of songs. This enables faster queue initialization for artists. [[1]](diffhunk://#diff-6c53bf76483f89e4e126787e25a40c3d7001cf6590b587c621e2e462cdbc8060L330-R331) [[2]](diffhunk://#diff-6c53bf76483f89e4e126787e25a40c3d7001cf6590b587c621e2e462cdbc8060R518-R527) [[3]](diffhunk://#diff-6c53bf76483f89e4e126787e25a40c3d7001cf6590b587c621e2e462cdbc8060L550-R568)
* The refresh logic in `needsRefresh` now considers the `isFullyCached` flag, ensuring that song population continues if the artist's cache is incomplete. [[1]](diffhunk://#diff-6c53bf76483f89e4e126787e25a40c3d7001cf6590b587c621e2e462cdbc8060L110-L115) [[2]](diffhunk://#diff-6c53bf76483f89e4e126787e25a40c3d7001cf6590b587c621e2e462cdbc8060L348-R349)
* The frontend `getArtistWithSongs` service method now requests only the first page of songs for immediate queue building, then triggers background pagination for the full list without blocking the UI.

**Queue and UI enhancements:**

* The `CacheAwareQueueManager` logs when it begins building the queue from first-page song IDs, improving traceability for the loading process.
* The queue display components now consistently apply the primary color to various text elements for improved visual consistency, and an unnecessary box-shadow was removed. [[1]](diffhunk://#diff-9723caf59036f7c98936971581d3095b4fa59196453247dea4ec6e298d1e0f4aL147) [[2]](diffhunk://#diff-9723caf59036f7c98936971581d3095b4fa59196453247dea4ec6e298d1e0f4aR215) [[3]](diffhunk://#diff-9723caf59036f7c98936971581d3095b4fa59196453247dea4ec6e298d1e0f4aR238) [[4]](diffhunk://#diff-9723caf59036f7c98936971581d3095b4fa59196453247dea4ec6e298d1e0f4aR248) [[5]](diffhunk://#diff-9723caf59036f7c98936971581d3095b4fa59196453247dea4ec6e298d1e0f4aR263)
* The close button in `AppWindow.svelte` was repositioned from the right to the left side of the title bar for better alignment.