### PR TITLE
added live wpm, and tidied of a few things visually

### DIFF
--- a/src/lib/components/LyricDisplay.svelte
+++ b/src/lib/components/LyricDisplay.svelte
@@ -461,13 +461,13 @@ function handleInput(event) {
 
   	// Function to end the test and calculate WPM and accuracy
 	function endTest() {
+		stopLiveWpmTracking();
 		endTime = new Date();
 		// Calculate actual typing time by subtracting pause time
 		const actualDuration = (endTime - startTime) - totalPauseTime;
 		const durationInMinutes = actualDuration / 60000;
 		const charactersTyped = userInput.length;
 		wpm = (charactersTyped / 5) / durationInMinutes;
-		stopLiveWpmTracking();
 
 		let incorrectChars = 0;
 		
@@ -508,8 +508,6 @@ function handleInput(event) {
 		testStarted = false;
 		totalPauseTime = 0;
 		pauseStartTime = null;
-		liveWpm = 0;
-		stopLiveWpmTracking();
 		setTimeout(() => { // Wait for the DOM to update before focusing the input
 			focusInput();
 		}, 0);

--- a/src/lib/components/LyricDisplay.svelte
+++ b/src/lib/components/LyricDisplay.svelte
@@ -42,6 +42,10 @@
 	let ditheredImageUrl = '';
 	let normalizedLyrics;
 	let blink = false;
+	
+	// Live WPM tracking
+	export let liveWpm = 0;
+	let liveWpmInterval = null;
   
 	$: windowHeight = $windowStore.windowStates.find(w => w.id === 'typingTestWindow')?.dimensions?.height;
 
@@ -72,6 +76,7 @@
 			return;
 		}
 		updateVisibleLines();
+		resetTypingTest();
 		console.log(`Scrolled up to line ${currentScrollLine}`);
 	}
 
@@ -90,6 +95,7 @@
 			return;
 		}
 		updateVisibleLines();
+		resetTypingTest();
 		console.log(`Scrolled down to line ${currentScrollLine}`);
 	}
 
@@ -112,6 +118,32 @@
 		console.log("resetting scroll position");
 		currentScrollLine = 0;
 		updateVisibleLines();
+	}
+
+	// Reset typing test state when scrolling to new lyrics section
+	function resetTypingTest() {
+		console.log("resetting typing test due to scroll");
+		// Reset all typing test state
+		showResults = false;
+		userInput = '';
+		testStarted = false;
+		startTime = null;
+		endTime = null;
+		cursorPosition = 0;
+		totalPauseTime = 0;
+		pauseStartTime = null;
+		liveWpm = 0;
+		
+		// Stop live WPM tracking
+		stopLiveWpmTracking();
+		
+		// Reset typing state classes
+		typingState.classes = [];
+		
+		// Focus the input after a short delay to ensure DOM is updated
+		setTimeout(() => {
+			focusInput();
+		}, 0);
 	}
 
 	// Reactive statement to process lyrics when they change
@@ -169,6 +201,70 @@
 			testStarted = true;
 			// Start dithering process when test starts
 			if (imageUrl) preloadAndDitherImage(imageUrl);
+			// Start live WPM tracking
+			startLiveWpmTracking();
+		}
+	}
+
+	// Calculate live WPM based on current progress
+	function calculateLiveWpm() {
+		if (!testStarted || !startTime) {
+			liveWpm = 0;
+			return;
+		}
+		
+		const currentTime = new Date();
+		// Calculate actual typing time by subtracting pause time
+		const currentPauseTime = pauseStartTime ? (currentTime - pauseStartTime) : 0;
+		const actualDuration = (currentTime - startTime) - totalPauseTime - currentPauseTime;
+		const durationInMinutes = actualDuration / 60000;
+		
+		if (durationInMinutes <= 0) {
+			liveWpm = 0;
+			return;
+		}
+		
+		const charactersTyped = userInput.length;
+		const rawWpm = (charactersTyped / 5) / durationInMinutes;
+		
+		// Calculate errors for penalty
+		let incorrectChars = 0;
+		if (typingState.classes) {
+			typingState.classes.forEach(item => {
+				if (item.type === 'word') {
+					item.chars.forEach(charClass => {
+						if (charClass === 'incorrect') {
+							incorrectChars++;
+						}
+					});
+				} else if (item.class === 'incorrect') {
+					incorrectChars++;
+				}
+			});
+		}
+		
+		// Apply error penalty (same as final calculation)
+		liveWpm = Math.max(rawWpm - (incorrectChars * 3), 0);
+	}
+
+	// Start live WPM tracking interval
+	function startLiveWpmTracking() {
+		if (liveWpmInterval) {
+			clearInterval(liveWpmInterval);
+		}
+		
+		liveWpmInterval = setInterval(() => {
+			if (testStarted && !isPaused) {
+				calculateLiveWpm();
+			}
+		}, 500); // Update every 500ms
+	}
+
+	// Stop live WPM tracking
+	function stopLiveWpmTracking() {
+		if (liveWpmInterval) {
+			clearInterval(liveWpmInterval);
+			liveWpmInterval = null;
 		}
 	}
 
@@ -176,6 +272,8 @@
 		showResults = false;
 		userInput = '';
 		testStarted = false;
+		liveWpm = 0;
+		stopLiveWpmTracking();
 		setTimeout(() => { // Wait for the DOM to update before focusing the input
 			focusInput();
 		}, 0);
@@ -211,6 +309,10 @@
 			cursorPosition = 0;
 			totalPauseTime = 0;
 			pauseStartTime = null;
+			liveWpm = 0;
+			
+			// Stop live WPM tracking
+			stopLiveWpmTracking();
 			
 			// Reset typing state classes
 			typingState.classes = [];
@@ -236,6 +338,7 @@
 		return () => {
 			window.removeEventListener('restartTest', handleRestartTest);
 			window.removeEventListener('unpauseTest', handleUnpauseTest);
+			stopLiveWpmTracking();
 		};
 	});
 
@@ -309,7 +412,11 @@ $: if ((capitalization !== lastCap || punctuation !== lastPunct) && (userInput.l
     totalPauseTime = 0;
     pauseStartTime = null;
     cursorPosition = 0;
+    liveWpm = 0;
     typingState.classes = [];
+
+    // Stop live WPM tracking
+    stopLiveWpmTracking();
 
     // Update last known values
     lastCap = capitalization;
@@ -360,6 +467,7 @@ function handleInput(event) {
 		const durationInMinutes = actualDuration / 60000;
 		const charactersTyped = userInput.length;
 		wpm = (charactersTyped / 5) / durationInMinutes;
+		stopLiveWpmTracking();
 
 		let incorrectChars = 0;
 		
@@ -400,6 +508,8 @@ function handleInput(event) {
 		testStarted = false;
 		totalPauseTime = 0;
 		pauseStartTime = null;
+		liveWpm = 0;
+		stopLiveWpmTracking();
 		setTimeout(() => { // Wait for the DOM to update before focusing the input
 			focusInput();
 		}, 0);

--- a/src/lib/components/ResultsDisplay.svelte
+++ b/src/lib/components/ResultsDisplay.svelte
@@ -104,7 +104,7 @@
                 </svg>
             </button>
             <button class="controlButton" tabindex=3 on:click={() => {window.open(geniusUrl, '_blank')}}>
-                <svg class="controlIconLarge" viewBox="0 0 24 24" fill="{$themeColors.primary}" xmlns="http://www.w3.org/2000/svg">
+                <svg class="controlIcon" viewBox="0 0 24 24" fill="{$themeColors.primary}" xmlns="http://www.w3.org/2000/svg">
                     <path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/>
                 </svg>
             </button>

--- a/src/lib/components/TypingTest.svelte
+++ b/src/lib/components/TypingTest.svelte
@@ -51,6 +51,9 @@
     let lyricsScrollUp = null;
     let lyricsScrollDown = null;
     
+    // Live WPM from LyricDisplay component
+    let liveWpm = 0;
+    
     // Debug reactive statement to monitor scroll function binding
     $: {
         console.log('TypingTest: Scroll functions updated', {
@@ -616,6 +619,7 @@
                             fullLyrics={currentSong?.fullLyrics}
                             bind:onScrollUp={lyricsScrollUp}
                             bind:onScrollDown={lyricsScrollDown}
+                            bind:liveWpm={liveWpm}
                         />
                     {:else}
                         {#if loading}
@@ -670,6 +674,10 @@
                 {#if songTitle}
                     <div class="songTitle" style:font-size="{windowHeight*0.034}px"> - {songTitle}</div>
                 {/if}
+            </div>
+            <div class="liveWpmContainer">
+                <p class="statLabel" style:font-size="{windowHeight*0.03}px">wpm:</p>
+                <p class="statValue" style:font-size="{windowHeight*0.045}px">{liveWpm.toFixed(1)}</p>
             </div>
         </div>
      </div>
@@ -807,8 +815,8 @@
 
     .queue-indicator {
         position: absolute;
-        top: -4px;
-        right: -4px;
+        top: -6.5px;
+        right: -6.5px;
         background: var(--primary-color);
         color: var(--secondary-color);
         border-radius: 50%;
@@ -818,7 +826,7 @@
         align-items: center;
         justify-content: center;
         font-family: "Geneva", sans-serif;
-        font-size: 12px;
+        font-size: 11px;
         font-weight: bold;
         border: 2px solid var(--secondary-color);
         min-width: 20px;
@@ -877,6 +885,27 @@
          font-size: 2vh;
          flex: 1;
          min-width: 0;
+     }
+
+     .liveWpmContainer {
+         display: flex;
+         flex-direction: column;
+         align-items: center;
+         justify-content: center;
+         padding-right: 2%;
+         min-width: 120px;
+     }
+
+     .statLabel {
+         font-size: 3vh;
+         margin: 0;
+         color: var(--primary-color);
+     }
+
+     .statValue {
+         font-size: 5vh;
+         margin: 0;
+         color: var(--primary-color);
      }
          .musicIconContainer {
          display: flex;


### PR DESCRIPTION
This pull request adds live words-per-minute (WPM) tracking to the typing test, allowing users to see their current WPM as they type. The main changes involve implementing the live WPM calculation logic, resetting and managing the WPM tracking state, and displaying the live WPM in the UI. There are also minor UI adjustments for consistency.

**Live WPM Tracking Implementation:**

* Added live WPM calculation and tracking logic to `LyricDisplay.svelte`, including functions to start/stop tracking, calculate live WPM with error penalties, and reset WPM state on scroll or test restart. [[1]](diffhunk://#diff-6544f6d5ae26587c17f33c3b4272fb71b5a83b8c1f6485fa090f143881d7dc2dR46-R49) [[2]](diffhunk://#diff-6544f6d5ae26587c17f33c3b4272fb71b5a83b8c1f6485fa090f143881d7dc2dR123-R148) [[3]](diffhunk://#diff-6544f6d5ae26587c17f33c3b4272fb71b5a83b8c1f6485fa090f143881d7dc2dR204-R276) [[4]](diffhunk://#diff-6544f6d5ae26587c17f33c3b4272fb71b5a83b8c1f6485fa090f143881d7dc2dR312-R315) [[5]](diffhunk://#diff-6544f6d5ae26587c17f33c3b4272fb71b5a83b8c1f6485fa090f143881d7dc2dR341) [[6]](diffhunk://#diff-6544f6d5ae26587c17f33c3b4272fb71b5a83b8c1f6485fa090f143881d7dc2dR415-R420) [[7]](diffhunk://#diff-6544f6d5ae26587c17f33c3b4272fb71b5a83b8c1f6485fa090f143881d7dc2dR464)
* Ensured live WPM tracking is reset or stopped on scrolling, replaying, restarting, or ending the test to prevent stale values. [[1]](diffhunk://#diff-6544f6d5ae26587c17f33c3b4272fb71b5a83b8c1f6485fa090f143881d7dc2dR79) [[2]](diffhunk://#diff-6544f6d5ae26587c17f33c3b4272fb71b5a83b8c1f6485fa090f143881d7dc2dR98) [[3]](diffhunk://#diff-6544f6d5ae26587c17f33c3b4272fb71b5a83b8c1f6485fa090f143881d7dc2dR123-R148) [[4]](diffhunk://#diff-6544f6d5ae26587c17f33c3b4272fb71b5a83b8c1f6485fa090f143881d7dc2dR312-R315) [[5]](diffhunk://#diff-6544f6d5ae26587c17f33c3b4272fb71b5a83b8c1f6485fa090f143881d7dc2dR341) [[6]](diffhunk://#diff-6544f6d5ae26587c17f33c3b4272fb71b5a83b8c1f6485fa090f143881d7dc2dR415-R420) [[7]](diffhunk://#diff-6544f6d5ae26587c17f33c3b4272fb71b5a83b8c1f6485fa090f143881d7dc2dR464)

**UI Integration and Display:**

* Passed the live WPM value from `LyricDisplay.svelte` to `TypingTest.svelte` using two-way binding, and displayed the live WPM in a new UI container during the test. [[1]](diffhunk://#diff-2613800a23e595d7018ebd67051cda63111bfa08e746a60e4f1502536100c19bR54-R56) [[2]](diffhunk://#diff-2613800a23e595d7018ebd67051cda63111bfa08e746a60e4f1502536100c19bR622) [[3]](diffhunk://#diff-2613800a23e595d7018ebd67051cda63111bfa08e746a60e4f1502536100c19bR678-R681) [[4]](diffhunk://#diff-2613800a23e595d7018ebd67051cda63111bfa08e746a60e4f1502536100c19bR889-R909)

**Minor UI Adjustments:**

* Adjusted the size and position of the queue indicator and related CSS for improved appearance. [[1]](diffhunk://#diff-2613800a23e595d7018ebd67051cda63111bfa08e746a60e4f1502536100c19bL810-R819) [[2]](diffhunk://#diff-2613800a23e595d7018ebd67051cda63111bfa08e746a60e4f1502536100c19bL821-R829)
* Fixed icon class usage in `ResultsDisplay.svelte` for consistency.