### PR TITLE
Fixed sizing issue for native album image rendering (non recolored version)

### DIFF
--- a/src/lib/components/ResultsDisplay.svelte
+++ b/src/lib/components/ResultsDisplay.svelte
@@ -371,4 +371,11 @@
         height: 75%;
         aspect-ratio: 1/1;
     }
+
+    .albumArt {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        display: block;
+    }
 </style>


### PR DESCRIPTION
This pull request adds a new CSS class to improve the display of album art in the `ResultsDisplay.svelte` component.

Styling improvements:

* Added a `.albumArt` CSS class to ensure album art images fill their container and maintain aspect ratio using `object-fit: contain`.